### PR TITLE
Apply Alertmanage for Slack and Telegram-BotFather

### DIFF
--- a/alertmanager/check_telegram.sh
+++ b/alertmanager/check_telegram.sh
@@ -1,0 +1,5 @@
+TOKEN="<bot-token>"
+ID="<Your group ID>"
+URL="https://api.telegram.org/bot$TOKEN/sendMessage"
+
+curl -s -X POST $URL -d chat_id=$ID -d text="Hello "

--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -1,11 +1,60 @@
-route:
-  receiver: 'slack'
+global:
+  resolve_timeout: 1m
+  slack_api_url: 'https://hooks.slack.com/services/<webhook-id>'
 
+route:
+  # continue: false
+  # group_by:
+  # - job
+  group_wait: 30s
+  group_interval: 1m
+  repeat_interval: 4h
+  receiver: 'slack-notifications'
+  routes:
+  - receiver: 'slack-notifications'
+    continue: true
+  - receiver: default-telegram
+
+  
 receivers:
-  - name: 'slack'
-    slack_configs:
-      - send_resolved: true
-        text: "{{ .CommonAnnotations.description }}"
-        username: 'Prometheus'
-        channel: '#<channel-name>'
-        api_url: 'https://hooks.slack.com/services/<webhook-id>'
+- name: 'slack-notifications'
+  slack_configs:
+  - channel: '#bh-webhook'
+    send_resolved: true
+    icon_url: https://avatars3.githubusercontent.com/u/3380462
+    title: |-
+      [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} for {{ .CommonLabels.job }}
+      {{- if gt (len .CommonLabels) (len .GroupLabels) -}}
+        {{" "}}(
+        {{- with .CommonLabels.Remove .GroupLabels.Names }}
+          {{- range $index, $label := .SortedPairs -}}
+            {{ if $index }}, {{ end }}
+            {{- $label.Name }}="{{ $label.Value -}}"
+          {{- end }}
+        {{- end -}}
+        )
+      {{- end }}
+    text: >-
+      {{ range .Alerts -}}
+      *Alert:* {{ .Annotations.title }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
+
+      *Description:* {{ .Annotations.description }}
+
+      *Details:*
+        {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+        {{ end }}
+      {{ end }}
+
+- name: default-telegram
+  telegram_configs:
+  - api_url: https://api.telegram.org
+    bot_token: <bot-token>
+    chat_id: <group-id>
+    disable_notifications: false
+    http_config:
+      follow_redirects: true
+    send_resolved: true
+    parse_mode: ""
+
+templates:
+- /etc/alertmanager/config/*.tmpl

--- a/alertmanager/config.yml
+++ b/alertmanager/config.yml
@@ -19,7 +19,7 @@ route:
 receivers:
 - name: 'slack-notifications'
   slack_configs:
-  - channel: '#bh-webhook'
+  - channel: '#<Your-chanel>' # Example: #bh-webhook
     send_resolved: true
     icon_url: https://avatars3.githubusercontent.com/u/3380462
     title: |-


### PR DESCRIPTION
Implement Alertmanager:
- [Slack](https://grafana.com/blog/2020/02/25/step-by-step-guide-to-setting-up-prometheus-alertmanager-with-slack-pagerduty-and-gmail/)
- [Telegram](https://core.telegram.org/bots/tutorial)
- [Setup multiple receivers](https://awesome-prometheus-alerts.grep.to/alertmanager.html)